### PR TITLE
Show group name to side bar

### DIFF
--- a/app/assets/stylesheets/modules/_side_bar.scss
+++ b/app/assets/stylesheets/modules/_side_bar.scss
@@ -30,11 +30,14 @@
   height: calc(100vh - 100px);
   background-color:#2f3e51;
   padding: 20px 20px 0;
-
+  overflow: scroll;
+  
+  a { 
+    text-decoration: none;
+  }
+  
   &__group {
     margin-bottom: 40px;
-    display: inline-block;
-    text-decoration: none;
     color: $white;
 
     &__name {

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,4 +5,12 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
 
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : "画像が投稿されています"
+    else
+      "まだメッセージはありません"
+    end
+  end
+
 end

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -13,8 +13,9 @@
 
   .groups
     - current_user.groups.each do |group|
-      = link_to group_messages_path(group), class: "groups__group" do
-        .groups__group__name
-          = group.name
-        .groups__group__currentMessage
-          メッセージはまだありません。
+      = link_to group_messages_path(group) do
+        .groups__group
+          .groups__group__name
+            = group.name
+          .groups__group__currentMessage
+            = group.show_last_message


### PR DESCRIPTION
# what
サイドバーに
グループ内で最後に送信した内容を表示する機能を追加。

・ 何もない場合は"まだメッセージはありません"と表示。
・ 最後が画像の場合は"画像が投稿されています"と表示。

# why
グループ一覧画面から最後のメッセージがわかることで、
前回のチャット内容がどこで終了したかが
すぐに把握できるようにする為。

