### PR TITLE
Show group name&group member to chat view

### DIFF
--- a/app/assets/stylesheets/modules/_main_chat.scss
+++ b/app/assets/stylesheets/modules/_main_chat.scss
@@ -30,6 +30,7 @@
       &__memberName {
         font-size: 12px;
         color: #999999;
+        margin-left: 0.3rem;
       }
     }
   }

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,11 +1,13 @@
 .chatView
   .header
     .header__groups
-      .header__groups__groupName testgroup
+      .header__groups__groupName
+        = @group.name
       .header__groups__memberNames
         .header__groups__memberNames__memberTitle Member :
-        .header__groups__memberNames__memberName name1
-        .header__groups__memberNames__memberName name2
+        - @group.users.each do |user|
+          .header__groups__memberNames__memberName
+            = user.name
     =link_to "Edit", "#", class: "header__btnEdit"
 
   .main


### PR DESCRIPTION
# what
メッセージグループのヘッダーに、
グループ名と、グループのメンバーの名称が
表示される機能を追加。

# why
どのグループに誰が所属しているかが
すぐにわかるようユーザービリティを向上。