### PR TITLE
Add auto reload chat

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -51,30 +51,30 @@ $(function(){
   })
 
   var reloadMessages = function() {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
     last_message_id = $(".main__messages__message").last().data("message_id");
     var urls = location.href.split("/");
     var group_id = urls[urls.length - 2];
     $.ajax({
-      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
       url: `/groups/${group_id}/api/messages`,
-      //ルーティングで設定したりhttpメソッドをgetに指定
       type: 'get',
       dataType: 'json',
-      //dataオプションでリクエストに値を含める
       data: {id: last_message_id}
     })
     .done(function(messages) {
+      
       var insertHTML = "";
       $.each(messages, function(i, message){
         insertHTML += buildHTML(message)
-      })
+      });
+
       $(".main__messages").append(insertHTML);
+      $('.main').animate({ scrollTop: $('.main')[0].scrollHeight});
+      console.log("発火");
     })
     .fail(function() {
       console.log('error');
     });
   };
 
-
+  setInterval(reloadMessages, 7000);
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -71,7 +71,7 @@ $(function(){
       $('.main').animate({ scrollTop: $('.main')[0].scrollHeight});
     })
     .fail(function() {
-      console.log('error');
+      alert("error");
     });
   };
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -69,7 +69,6 @@ $(function(){
 
       $(".main__messages").append(insertHTML);
       $('.main').animate({ scrollTop: $('.main')[0].scrollHeight});
-      console.log("発火");
     })
     .fail(function() {
       console.log('error');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -6,7 +6,7 @@ $(function(){
                       </div>`
                       : "";
                       
-      var html = `<div class="main__messages__message">
+      var html = `<div class="main__messages__message" data-message_id=${message.id} >
                     <div class="main__messages__message__heading">
                       <div class="main__messages__message__heading__name">
                         ${message.name}
@@ -49,4 +49,32 @@ $(function(){
       alert("error");
     })
   })
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    last_message_id = $(".main__messages__message").last().data("message_id");
+    var urls = location.href.split("/");
+    var group_id = urls[urls.length - 2];
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: `/groups/${group_id}/api/messages`,
+      //ルーティングで設定したりhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      var insertHTML = "";
+      $.each(messages, function(i, message){
+        insertHTML += buildHTML(message)
+      })
+      $(".main__messages").append(insertHTML);
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+
+
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -76,5 +76,7 @@ $(function(){
     });
   };
 
-  setInterval(reloadMessages, 7000);
+  if(location.href.match(/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}") 
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body message.body
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.body message.body
   json.image message.image.url
-  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-  json.user_name message.user.name
+  json.created_at message.created_at.strftime("%Y/%m/%d/(%a) %T")
+  json.name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main__messages__message
+.main__messages__message{ "data-message_id": message.id}
   .main__messages__message__heading
     .main__messages__message__heading__name
       = message.user.name

--- a/app/views/messages/api/messages/index.json.jbuilder
+++ b/app/views/messages/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body message.body
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/api/messages/index.json.jbuilder
+++ b/app/views/messages/api/messages/index.json.jbuilder
@@ -1,7 +1,0 @@
-json.array! @messages do |message|
-  json.body message.body
-  json.image message.image.url
-  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-  json.user_name message.user.name
-  json.id message.id
-end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.body @message.body
 json.image @message.image.url
 json.created_at @message.created_at.strftime("%Y/%m/%d/(%a) %T")
 json.name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: {format: "json"}
+    end
   end
 end


### PR DESCRIPTION
# what
グループ内のメッセージを
7秒おきに自動で更新する機能を実装。

### 確認動画
- メッセージの自動更新
https://gyazo.com/ef1576ba815eec2eb2e7898ad9ece913

- メッセージ画面以外での挙動
  (イベント発火していないことの確認)
https://gyazo.com/8c349edb0af95aa36f5d5084db0f2379

# why
自分以外のグループメンバーが
メッセージを送信した際に、
画面更新を行わなくても自動で更新される為、
スムーズにメッセージのやりとりを行うことができる。